### PR TITLE
Avoid referencing jaword-mode from autoloaded advices

### DIFF
--- a/jaword.el
+++ b/jaword.el
@@ -203,7 +203,7 @@ accuracy, but slower speed."
 ;;;###autoload
 (defadvice isearch-yank-word-or-char (around jaword-support-isearch activate)
   "Add support for jaword."
-  (if jaword-mode
+  (if (bound-and-true-p jaword-mode)
       (isearch-yank-internal
        (lambda ()
          (if (or (= (char-syntax (or (char-after) 0)) ?w)
@@ -216,7 +216,7 @@ accuracy, but slower speed."
 ;;;###autoload
 (defadvice isearch-yank-word (around jaword-support-isearch activate)
   "Add support for jaword."
-  (if jaword-mode
+  (if (bound-and-true-p jaword-mode)
       (isearch-yank-internal (lambda () (jaword-forward 1) (point)))
     ad-do-it))
 


### PR DESCRIPTION
`jaword-mode` is not yet a declared variable at the stage when these defadvice directives are evaluated and byte-compiled via autoloads, so every time Emacs starts up you get the following runtime warning(s):

```
Warning (bytecomp): reference to free variable ‘jaword-mode’ [2 times]
```

This commit fixes it.